### PR TITLE
Possible error in computing tau in BchronCalibrate?

### DIFF
--- a/R/BchronCalibrate.R
+++ b/R/BchronCalibrate.R
@@ -116,7 +116,7 @@ function(ages,ageSds,calCurves,ids=NULL,positions=NULL,pathToCalCurves=system.fi
       stop(paste("Date",ids[i],"outside of calibration range. Range of", calCurves[i], 'is',cal_range[1],'to',cal_range[2]))
     }
 
-    tau = ageSds[i]^2 + tau1[[matchCalCurves[i]]]
+    tau = ageSds[i]^2 + tau1[[matchCalCurves[i]]]^2
 
     currAgeGrid = ageGrid[[matchCalCurves[i]]]
     dens = stats::dt((ages[i]-mu[[matchCalCurves[i]]])/sqrt(tau),df=dfs[i])


### PR DESCRIPTION
There is a possible error in the computation of `tau` in `BchronCalibrate()`. This was detected when comparing _Bchron_ to _rcarbon_ and _OxCal_ (via oxcAAR). There are still some differences after the fix but this is presumably due to the use of the t distribution? 

```
library(Bchron)
library(rcarbon)
library(oxcAAR)


x1=BchronCalibrate(4000,40,calCurves='intcal13')
x2=calibrate(4000,40)
quickSetupOxcal()
x3=oxcalCalibrate(4000,40)


plot(x1$Date1$ageGrid,x1$Date1$densities,type='l')
lines(x2$grids[[1]][,1],x2$grids[[1]][,2],col='red',lty=2)
oxcalDF= x3[[1]][6][[1]]
lines(abs(round(oxcalDF[,1])-1950), oxcalDF[,2],lty=3,col='blue')
```